### PR TITLE
Allow using renoweb as a package from another project

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ func main() {
 		if t == t {
 		}
 		log.Info("Getting data from RenoWeb")
-		addressID := renoweb.GetRenoWebAddressID(cfg)
+		addressID := renoweb.GetRenoWebAddressID(cfg.Section("renoweb").Key("address").String())
 		pickupPlans := renoweb.GetRenoWebPickupPlan(addressID)
 		log.Info("Done getting data from RenoWeb")
 

--- a/renoweb/renoweb.go
+++ b/renoweb/renoweb.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 
 	"github.com/anderskvist/DVIEnergiSmartControl/log"
-	ini "gopkg.in/ini.v1"
 )
 
 type addressSearchSearch struct {
@@ -62,9 +61,9 @@ func jsonPrettyPrint(in string) string {
 	return out.String()
 }
 
-func GetRenoWebAddressID(cfg *ini.File) int {
+func GetRenoWebAddressID(needle string) int {
 	search := addressSearchSearch{
-		Searchterm:          cfg.Section("renoweb").Key("address").String(),
+		Searchterm:          needle,
 		Addresswithmateriel: 3}
 
 	jsondata, _ := json.Marshal(search)


### PR DESCRIPTION
This will allow foreign usage of the renoweb package without knowing anything about the configuration format.